### PR TITLE
fix(doc): grammar and readability improvements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,36 @@
 # nvim-plugin-template
 
-Neovim plugin template; includes automatic documentation generation from README, integration tests with Busted, and linting with Stylua
+A template repository for neovim plugins. Includes automatic doc generation based on your project's README, integration tests with Busted, and linting via Stylua.
 
 ## Usage
 
-1. Click `use this template` button generate a repo on your github.
-2. Clone your plugin repo. Open terminal then cd plugin directory.
-3. Run `python3 rename.py your-plugin-name`. This will replace all `nvim-plugin-template` to your `plugin-name`. 
-   Then it will prompt you input `y` or `n` to remove example codes in `init.lua` and
-   `test/plugin_spec.lua`. If you are familiar this repo just input `y`. If you are looking at this template for the first time I suggest you inspect the contents. After this step `rename.py` will also auto-remove.
+1. Click `use this template` button generate a repo under your github account.
+2. Clone the newly-created repository, open a terminal, and cd to the plugin directory.
+3. Run `python3 rename.py your-plugin-name`. This will:
+    1. Replace all occurrences of `nvim-plugin-template` with `your-plugin-name`.
+    2. Promt you for `y` or `n` to remove example code in `init.lua` and `test/plugin_spec.lua`.
+        - If you are familiar with this repo, just select `y`.
+        - Otherwise, I suggest you inspect the contents of thses files first.
+    3. Lastly, `rename.py` will auto-remove itself.
 
-Now you have a clean plugin environment. Enjoy!
+Now you have a clean plugin development environment. Enjoy!
 
 ## Format
 
-The CI uses `stylua` to format the code; customize the formatting by editing `.stylua.toml`.
+The CI uses `stylua` to format the code. Customize the formatting by editing `.stylua.toml`.
 
 ## Test
 
-See [Running tests locally](https://github.com/nvim-neorocks/nvim-busted-action?tab=readme-ov-file#running-tests-locally)
+See [running tests locally](https://github.com/nvim-neorocks/nvim-busted-action?tab=readme-ov-file#running-tests-locally).
 
 ## CI
 
-- Auto generates doc from README.
-- Runs the [nvim-busted-action](https://github.com/nvim-neorocks/nvim-busted-action) for test.
+- Auto-generates doc from README.
+- Runs the [nvim-busted-action](https://github.com/nvim-neorocks/nvim-busted-action) for tests.
 - Lints with `stylua`.
 
 ## More
 
 To see this template in action, take a look at my other plugins.
 
-## License MIT
+## License: MIT


### PR DESCRIPTION
Some grammar fixes and readability improvements. Mostly in the *Usage* section, as well as in the opening sentence.

I would also like to suggest changing the repository description to read more like this:

"Neovim plugin template with integration for tests, linting, and doc publishing"

(Currently it reads, "neovim plugin template integration test and doc publish")

Lastly, I would like to suggest adding some tags to this repo, which would improve its visibility. Something like `neovim-plugin-template`, as well as `template` would go well. It might be worth checking if there are any other plugin templates that have tags you could borrow.

Thanks for your work on this!